### PR TITLE
Allow actual file:// URL's (as long as they stay in the app's base path)

### DIFF
--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -439,13 +439,13 @@
     }
 
     NSURL *base = [self xhrBaseURL];
-	NSURL *final = nil;
-	if ([relativePath hasPrefix:@"file://"]) {
-		final = [[NSURL URLWithString:relativePath] standardizedURL];
-	}
-	else {
-		final = [[base URLByAppendingPathComponent:relativePath] standardizedURL];
-	}
+    NSURL *final = nil;
+    if ([relativePath hasPrefix:@"file://"]) {
+        final = [[NSURL URLWithString:relativePath] standardizedURL];
+    }
+    else {
+        final = [[base URLByAppendingPathComponent:relativePath] standardizedURL];
+    }
 
     // Security sensitive
     // Ensure URL does not leave the base URL

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -439,7 +439,13 @@
     }
 
     NSURL *base = [self xhrBaseURL];
-    NSURL *final = [[base URLByAppendingPathComponent:relativePath] standardizedURL];
+	NSURL *final = nil;
+	if ([relativePath hasPrefix:@"file://"]) {
+		final = [[NSURL URLWithString:relativePath] standardizedURL];
+	}
+	else {
+		final = [[base URLByAppendingPathComponent:relativePath] standardizedURL];
+	}
 
     // Security sensitive
     // Ensure URL does not leave the base URL

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -29,10 +29,14 @@
 #define CDV_WKWEBVIEW_FILE_URL_LOAD_SELECTOR @"loadFileURL:allowingReadAccessToURL:"
 
 @interface CDVWKWebViewEngine ()
+{
+	NSURL *appDataHome;
+}
 
 @property (nonatomic, strong, readwrite) NSOperationQueue* fileQueue;
 @property (nonatomic, strong, readwrite) UIView* engineWebView;
 @property (nonatomic, strong, readwrite) id <WKUIDelegate> uiDelegate;
+@property (nonatomic, assign) BOOL allowFilesFromAppHome;
 
 @end
 
@@ -97,6 +101,7 @@
         NSLog(@"CDVWKWebViewEngine: skipped XHR polyfill");
     }
 
+	self.allowFilesFromAppHome = [settings cordovaBoolSettingForKey:@"AllowFilesFromAppHome" defaultValue:YES];
 
     WKWebViewConfiguration* configuration = [self createConfigurationFromSettings:settings];
     configuration.userContentController = userContentController;
@@ -238,6 +243,11 @@
             }
         }
     }
+	
+	NSURL *baseDir = [[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask].lastObject;
+	appDataHome = [baseDir URLByDeletingLastPathComponent];
+
+   	self.allowFilesFromAppHome = [settings cordovaBoolSettingForKey:@"AllowFilesFromAppHome" defaultValue:YES];
 
     wkWebView.scrollView.scrollEnabled = [settings cordovaFloatSettingForKey:@"ScrollEnabled" defaultValue:YES];
 
@@ -449,7 +459,9 @@
 
     // Security sensitive
     // Ensure URL does not leave the base URL
-    if (![[final absoluteString] hasPrefix:[base absoluteString]]) {
+    if (![[final absoluteString] hasPrefix:[base absoluteString]] &&
+		(!self.allowFilesFromAppHome || ![[final absoluteString] hasPrefix:appDataHome.absoluteString]))
+	{
         NSLog(@"CDVWKWebViewEngine: requested path can not be accessed: %@", final);
         return nil;
     }

--- a/src/ios/xhr.js
+++ b/src/ios/xhr.js
@@ -76,7 +76,8 @@
 
 
   XHRPrototype.open = function _wk_open(method, url, async) {
-    if (!(/^[a-zA-Z0-9]+:\/\//.test(url))) {
+    // capture URL's that either start with "file://" or don't have a protocol
+    if (/^file:\/\//.test(url) || !(/^[a-zA-Z0-9]+:\/\//.test(url))) {
       console.debug("XHR polyfill: open() intercepted XHR:", url);
       this.__setURL(url);
       this.__set('readyState', 1); // OPENED

--- a/src/ios/xhr.js
+++ b/src/ios/xhr.js
@@ -206,12 +206,15 @@
     }
     console.debug("XHR polyfill: Response received: ", context.__getURL());
     var buffer = decodeBase64(base64);
-    switch (context.responseText) {
+    switch (context.responseType) {
       case 'arraybuffer':
         context.__set('response', buffer);
         break;
+      case 'blob':
+        context.__set('response', new Blob([buffer]));
+        break;
       default:
-        console.error('Unknown responseText:', context.responseText);
+        console.error('Unknown responseType:', context.responseType);
       case 'text':
       case '':
         var response = utf8Decode(buffer);


### PR DESCRIPTION
Allow actual “file://“ url’s to be intercepted by the XHR polyfill.