### PR TITLE
fix(error): ios, fix #119 when load remote url failed, should also fallback to errorURL

### DIFF
--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -450,6 +450,16 @@ static void * KVOContext = &KVOContext;
 
 - (void)webView:(WKWebView*)theWebView didFailNavigation:(WKNavigation*)navigation withError:(NSError*)error
 {
+    [self handleNavigationError:theWebView error: error];
+}
+
+- (void)webView:(WKWebView*)theWebView didFailProvisionalNavigation:(WKNavigation*)navigation withError:(NSError*)error
+{
+    [self handleNavigationError:theWebView error: error];
+}
+
+- (void)handleNavigationError:(WKWebView*)theWebView error:(NSError*)error
+{
     CDVViewController* vc = (CDVViewController*)self.viewController;
     [CDVUserAgentUtil releaseLock:vc.userAgentLockToken];
 


### PR DESCRIPTION
fix #119

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

ios
### What does this PR do?
when load remote url failed, should also fallback to errorURL
### What testing has been done on this change?
local test
### Checklist
- [*] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

add didFailProvisionalNavigation callback to also fallback to errorURL
